### PR TITLE
Pathlib included in stdlib py3.4+

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,20 @@
 
+import sys
 from setuptools import setup
 
-requirements = [
-    "numpy",
-    "pandas",
-    "pathlib"
-]
+if (sys.version_info.major == 3 and sys.version_info.minor >= 4):
+    # Pathlib should be avail. from Python 3.4
+    # https://docs.python.org/3/library/pathlib.html
+    requirements = [
+        "numpy",
+        "pandas",
+    ]
+else:
+    requirements = [
+        "numpy",
+        "pandas",
+        "pathlib"
+    ]
 
 
 setup(


### PR DESCRIPTION
Pathlib has been available in stdlib since Python 3.4 (https://docs.python.org/3/library/pathlib.html), and it seems like there is no pathlib pip package for Python 3.10.

This patch makes aquacrop-eto usable in Python 3.10